### PR TITLE
Add filter command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -16,9 +16,12 @@ Finding your next lead has never been easier.
     * [Retrieve particular contact: view](#retrieve-particular-contact--view)
     * [Update existing contact: update](#update-existing-contact--update)
     * [Delete particular contact: delete](#delete-particular-contact--delete)
+    * [List all contacts](#list-all-contacts--list)
     * [Clearing all entries: clear](#clearing-all-entries--clear)
     * [Sort Contacts: sort](#sort-contacts--sort)
-    * [Locating clients by keywords: find](#locating-clients-by-keywords--find)
+    * [Locating person by name: find](#locating-clients-by-keywords--find)
+    * [Locating clients by keywords](#locating-clients-by-keywords--search)
+    * [Filter current list](#filter-current-list-by-keywords--filter)
     * [Exiting the program: exit](#exiting-the-program--exit)
     * [Saving data](#saving-the-data)
     * [Edit data file](#editing-data-file)
@@ -58,6 +61,7 @@ Finding your next lead has never been easier.
 ## Client Information
 
 Every client that is registered in LeadsForce have the following attributes that has the corresponding attribute type and argument tag.
+
 Client Attribute | Type of Attribute | Argument Tag
 -----------------|-----------------|-----------------
 Client ID (**unique**) | integer | None. Assigned on creation of new contact
@@ -197,6 +201,28 @@ Examples:
 * `search John` returns `john` and `John Doe`
 * `search alex david` returns `Alex Yeoh`, `David Li`<br>
 
+### Filter current list by keywords : `filter`
+
+Filter the current list by the given keywords.
+
+Format: `filter KEYWORD [MORE_KEYWORDS]... [ATTRIBUTE/ATTRIBUTE_KEYWORD]...`
+
+* Works similar to `search` but `filter` works based on the current list shown as opposed to entire lists of contacts.
+* `KEYWORD` and `MORE_KEYWORDS` will be used to match will all attribute of the person
+* `attribute/` refers to the argument tag for the client's attribute.
+* `ATTRIBUTE_KEYWORD` refers to the keyword that is to be matched with the corresponding client attribute.
+* `*` can be used for the `KEYWORD` along with 1 or more `ATTRIBUTE/ATTRIBUTE_KEYWORD` to filter using only attribute.
+* The filter is case-insensitive. e.g `keith` will match `Keith`.
+* The order of the keywords does not matter. e.g. `John Doe` will match `Doe John`.
+* Clients matching at least one keyword will be returned (i.e. `OR` filter).
+  e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`.
+* Only clients whose attribute matches with the attribute keyword will be returned (i.e. `AND` search), if attribute keyword is provided.
+  e.g. `Tom Tim e/@gmail.com` will return `Tom Lee e/Tom@gmail.com` and not `Tim Shum e/Tim@yahoo.com`.
+
+Examples:
+* `search John` returns `john` and `John Doe`
+* `search alex david` returns `Alex Yeoh`, `David Li`<br>
+
 ### Clearing all entries : `clear`
 
 Clears all entries from the address book.
@@ -241,5 +267,6 @@ Action | Format | Examples
 **List** | `list` | - |
 **Find** | `find KEYWORD [OTHER_KEYWORD]` | find alex tom |
 **Search** | `search KEYWORD [OTHER_KEYWORD] [ATTRIBUTE/ATTRIBUTE_KEYWORD]...` | search * email/doe@gmail.com risk-appetite/5 |
+**Filter** | `filter KEYWORD [OTHER_KEYWORD] [ATTRIBUTE/ATTRIBUTE_KEYWORD]...` | search * email/doe@gmail.com p/9 |
 **Sort** | `sort <attribute>/{ASC/DESC}` | sort risk-appetite/asc |
 **Exit** | `exit` | - |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -167,7 +167,7 @@ Examples:
 
 Finds persons whose names contain any of the given keywords.
 
-Format: `find KEYWORD [MORE_KEYWORDS]`
+Format: `find KEYWORD [MORE_KEYWORDS]...`
 
 * The search is case-insensitive. e.g `hans` will match `Hans`
 * The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
@@ -186,10 +186,10 @@ Finds clients whose contacts match with the given keywords.
 
 Format: `search KEYWORD [MORE_KEYWORDS]... [ATTRIBUTE/ATTRIBUTE_KEYWORD]...`
 
-* `KEYWORD` and `MORE_KEYWORDS` will be used to match will all attribute of the person
-* `attribute/` refers to the argument tag for the client's attribute.
+* `KEYWORD` and `MORE_KEYWORDS` will be used to match will all attribute of the person.
+* `ATTRIBUTE/` refers to the argument tag for the client's attribute.
 * `ATTRIBUTE_KEYWORD` refers to the keyword that is to be matched with the corresponding client attribute.
-* `*` can be used for the `KEYWORD` along with 1 or more `ATTRIBUTE/ATTRIBUTE_KEYWORD` to search using only attribute.
+* If no `KEYWORD` is provided, search will be based on `ATTRIBUTE/ATTRIBUTE_KEYWORD` only.
 * The search is case-insensitive. e.g `keith` will match `Keith`.
 * The order of the keywords does not matter. e.g. `John Doe` will match `Doe John`.
 * Clients matching at least one keyword will be returned (i.e. `OR` search).
@@ -205,13 +205,13 @@ Examples:
 
 Filter the current list by the given keywords.
 
-Format: `filter KEYWORD [MORE_KEYWORDS]... [ATTRIBUTE/ATTRIBUTE_KEYWORD]...`
+Format: `filter [KEYWORD]... [ATTRIBUTE/ATTRIBUTE_KEYWORD]...`
 
 * Works similar to `search` but `filter` works based on the current list shown as opposed to entire lists of contacts.
-* `KEYWORD` and `MORE_KEYWORDS` will be used to match will all attribute of the person
-* `attribute/` refers to the argument tag for the client's attribute.
+* `KEYWORD` will be used to match will all attribute of the person.
+* If no `KEYWORD` is provided, then filter will be based on `ATTRIBUTE/ATTRIBUTE_KEYWORDS`
+* `ATTRIBUTE/` refers to the argument tag for the client's attribute.
 * `ATTRIBUTE_KEYWORD` refers to the keyword that is to be matched with the corresponding client attribute.
-* `*` can be used for the `KEYWORD` along with 1 or more `ATTRIBUTE/ATTRIBUTE_KEYWORD` to filter using only attribute.
 * The filter is case-insensitive. e.g `keith` will match `Keith`.
 * The order of the keywords does not matter. e.g. `John Doe` will match `Doe John`.
 * Clients matching at least one keyword will be returned (i.e. `OR` filter).
@@ -266,7 +266,7 @@ Action | Format | Examples
 **Update** | `update {Client’s id number} <attribute>/{change value of attribute}` | update 1234 name/Dominic phone-number/12345678 |
 **List** | `list` | - |
 **Find** | `find KEYWORD [OTHER_KEYWORD]` | find alex tom |
-**Search** | `search KEYWORD [OTHER_KEYWORD] [ATTRIBUTE/ATTRIBUTE_KEYWORD]...` | search * email/doe@gmail.com risk-appetite/5 |
+**Search** | `search [KEYWORD]... [ATTRIBUTE/ATTRIBUTE_KEYWORD]...` | search * email/doe@gmail.com risk-appetite/5 |
 **Filter** | `filter KEYWORD [OTHER_KEYWORD] [ATTRIBUTE/ATTRIBUTE_KEYWORD]...` | search * email/doe@gmail.com p/9 |
 **Sort** | `sort <attribute>/{ASC/DESC}` | sort risk-appetite/asc |
 **Exit** | `exit` | - |

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -1,0 +1,38 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
+
+public class FilterCommand extends Command {
+
+    public static final String COMMAND_WORD = "filter";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filter the currently displayed list of persons by"
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + "e/example.com";
+
+    private final PersonContainsKeywordsPredicate predicate;
+
+    public FilterCommand(PersonContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.filterFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FilterCommand // instanceof handles nulls
+                && predicate.equals(((FilterCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -63,6 +64,9 @@ public class AddressBookParser {
 
         case SearchCommand.COMMAND_WORD:
             return new SearchCommandParser().parse(arguments);
+
+        case FilterCommand.COMMAND_WORD:
+            return new FilterCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -26,8 +26,11 @@ public class FilterCommandParser implements Parser<FilterCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }
 
+
+        // appends " " in front as Filter Command can accept arguments without a preamble
+        String preparedArgs = " ".concat(trimmedArgs);
         ArgumentMultimap argMultimap = ArgumentTokenizer
-                .tokenize(trimmedArgs, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                .tokenize(preparedArgs, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_LASTMET, PREFIX_CURRENTPLAN, PREFIX_TAG);
         return new FilterCommand(new PersonContainsKeywordsPredicate(argMultimap));
     }

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -2,35 +2,33 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CURRENTPLAN;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LASTMET;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import seedu.address.logic.commands.SearchCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.PersonContainsKeywordsPredicate;
 
-/**
- * Parses input arguments and creates a new FindCommand object
- */
-public class SearchCommandParser implements Parser<SearchCommand> {
-
+public class FilterCommandParser implements Parser<FilterCommand> {
     /**
-     * Parses the given {@code String} of arguments in the context of the SearchCommand
-     * and returns a SearchCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the FilterCommand
+     * and returns a FilterCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public SearchCommand parse(String args) throws ParseException {
+    public FilterCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim().replaceAll("\\s+", " ");
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }
 
         ArgumentMultimap argMultimap = ArgumentTokenizer
-                .tokenize(trimmedArgs, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
-        return new SearchCommand(new PersonContainsKeywordsPredicate(argMultimap));
+                .tokenize(trimmedArgs, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_LASTMET, PREFIX_CURRENTPLAN, PREFIX_TAG);
+        return new FilterCommand(new PersonContainsKeywordsPredicate(argMultimap));
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
@@ -28,8 +28,10 @@ public class SearchCommandParser implements Parser<SearchCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
         }
 
+        // appends " " in front as Search Command can accept arguments without a preamble
+        String preparedArgs = " ".concat(trimmedArgs);
         ArgumentMultimap argMultimap = ArgumentTokenizer
-                .tokenize(trimmedArgs, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                .tokenize(preparedArgs, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
         return new SearchCommand(new PersonContainsKeywordsPredicate(argMultimap));
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -84,4 +84,10 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Updates the filter of the filtered person list to filter by current predicate and the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void filterFilteredPersonList(Predicate<Person> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -130,6 +130,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void filterFilteredPersonList(Predicate<Person> predicate) {
+        requireNonNull(predicate);
+        filteredPersons.setPredicate(predicate.and(filteredPersons.getPredicate()));
+    }
+
+    @Override
     public boolean equals(Object obj) {
         // short circuit if same object
         if (obj == this) {

--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -17,7 +17,6 @@ import seedu.address.logic.parser.ArgumentMultimap;
  * Tests that a {@code Person}'s attributes matches any of the keywords given.
  */
 public class PersonContainsKeywordsPredicate implements Predicate<Person> {
-    private static final String WILDCARD_KEYWORD = "*";
     private final ArgumentMultimap keywords;
 
     public PersonContainsKeywordsPredicate(ArgumentMultimap keywords) {
@@ -27,8 +26,7 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         String[] generalKeywords = keywords.getPreamble().split(" ");
-        boolean checkGeneral = generalKeywords[0].equals(WILDCARD_KEYWORD)
-            || Arrays.stream(generalKeywords).anyMatch(x -> {
+        boolean checkGeneral = generalKeywords[0].isBlank() || Arrays.stream(generalKeywords).anyMatch(x -> {
                 boolean checkAttribute = Stream.of(person.getName().fullName, person.getPhone().value,
                     person.getEmail().value, person.getAddress().value).anyMatch(y -> containsIgnoreCase(y, x));
                 boolean checkAttributeTag = person.getTags().stream()

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -149,6 +149,11 @@ public class AddCommandTest {
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void filterFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -1,17 +1,5 @@
 package seedu.address.logic.commands;
 
-import seedu.address.logic.parser.ArgumentMultimap;
-import seedu.address.logic.parser.ArgumentTokenizer;
-import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
-import seedu.address.model.person.PersonContainsKeywordsPredicate;
-
-import java.util.Arrays;
-import java.util.Collections;
-
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -26,6 +14,18 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
 
 public class FilterCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -1,0 +1,101 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+public class FilterCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        PersonContainsKeywordsPredicate firstPredicate =
+                new PersonContainsKeywordsPredicate(
+                        ArgumentTokenizer.tokenize("abc def a/Blk 30 e/example.com"));
+        PersonContainsKeywordsPredicate secondPredicate =
+                new PersonContainsKeywordsPredicate(ArgumentTokenizer.tokenize("abc a/Blk 30"));
+
+        FilterCommand filterFirstCommand = new FilterCommand(firstPredicate);
+        FilterCommand filterSecondCommand = new FilterCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(filterFirstCommand.equals(filterFirstCommand));
+
+        // same values -> returns true
+        FilterCommand findFilterCommandCopy = new FilterCommand(firstPredicate);
+        assertTrue(filterFirstCommand.equals(findFilterCommandCopy));
+
+        // different types -> returns false
+        assertFalse(filterFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(filterFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(filterFirstCommand.equals(filterSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        PersonContainsKeywordsPredicate predicate = preparePredicate("* e/not_example.com");
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.filterFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        PersonContainsKeywordsPredicate predicate = preparePredicate("Pauline Kurz Elle Kunz p/94 e/example.com");
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.filterFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, ELLE, FIONA), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleFilter() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        PersonContainsKeywordsPredicate predicate1 = preparePredicate("Pauline Kurz Elle Kunz p/94 e/example.com");
+        PersonContainsKeywordsPredicate predicate2 = preparePredicate("* a/ave");
+        FilterCommand command1 = new FilterCommand(predicate2);
+        FilterCommand command2 = new FilterCommand(predicate1);
+        expectedModel.filterFilteredPersonList(predicate1);
+        expectedModel.filterFilteredPersonList(predicate2);
+        command1.execute(model);
+        assertCommandSuccess(command2, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, ELLE), model.getFilteredPersonList());
+    }
+
+    private PersonContainsKeywordsPredicate preparePredicate(String s) {
+        ArgumentMultimap aMM = ArgumentTokenizer.tokenize(s,
+                PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+        return new PersonContainsKeywordsPredicate(aMM);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -24,6 +24,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -91,6 +92,16 @@ public class AddressBookParserTest {
         SearchCommand command = (SearchCommand) parser.parseCommand(
                 SearchCommand.COMMAND_WORD + " " + keywords);
         assertEquals(new SearchCommand(new PersonContainsKeywordsPredicate(aMM)), command);
+    }
+
+    @Test
+    public void parseCommand_filter() throws Exception {
+        String keywords = "do t/friends e/example.com";
+        ArgumentMultimap aMM = ArgumentTokenizer.tokenize(keywords,
+                PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+        FilterCommand command = (FilterCommand) parser.parseCommand(
+                FilterCommand.COMMAND_WORD + " " + keywords);
+        assertEquals(new FilterCommand(new PersonContainsKeywordsPredicate(aMM)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -1,10 +1,5 @@
 package seedu.address.logic.parser;
 
-import seedu.address.logic.commands.FilterCommand;
-import seedu.address.model.person.PersonContainsKeywordsPredicate;
-
-import org.junit.jupiter.api.Test;
-
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -13,6 +8,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
 
 public class FilterCommandParserTest {
 

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
+
+import org.junit.jupiter.api.Test;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+public class FilterCommandParserTest {
+
+    private FilterCommandParser parser = new FilterCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FilterCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFilterCommand() {
+        // no leading and trailing whitespaces
+        FilterCommand expectedFilterCommand =
+                new FilterCommand(new PersonContainsKeywordsPredicate(
+                        ArgumentTokenizer.tokenize("Alice Bob e/example.com a/Blk 30",
+                                PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG)
+                ));
+        assertParseSuccess(parser, "Alice Bob e/example.com a/Blk 30", expectedFilterCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n Alice \n \t Bob  \t e/example.com a/Blk 30", expectedFilterCommand);
+    }
+}


### PR DESCRIPTION
### Description

Added Filter Command along with respective Parser class.
Include filterFilteredPersonList method in Model to AND(Compound/Chain) new predicate with current predicate
Minor Update to Search Command to be more generic where there is no more need to use wildcard by default

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Filter Command format: filter KEYWORDS [MORE_KEYWORDS]... [ATTRIBUTE/ATTRIBUTE_KEYWORD]...
Using the default/sample addressbook (delete tp/data/addressbook.json file before running the addressbook if not using the default addressbook)

Sample inputs: Inputs with the same number should be tested in sequence and `list` command should be executed between inputs of different number

1a. filter alex yu li e/example.com t/friends will return Alex and Bernice
1b. filter a/blk 30 p/8 will still return Alex and Bernice
1c. filter e/yeoh@example.com will return Alex

2a. filter a/Serangoon will return Bernice and David
2b. filter a/Ang Mo Kio p/98 will return no one.
2c. filter tan yu li will still return no one.

3a. filter a p/9 e/example.com t/family will return David
3b. filter David a/serangoon gardens should still return David

4a. filter t/friends a/Ang Mo Kio p/91 e/example.com will return no one
4b. filter a/blk 30 will still return no one.

### Checklist

- [X] I have tested this code
- [X] I have updated the documentation

Closes #37 