### PR TITLE
Update predicate to check for tags

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -252,8 +252,8 @@ Format: `filter {KEYWORD}... <attribute>/{ATTRIBUTE_KEYWORD}...`
   e.g. `Tom Tim e/@gmail.com` will return `Tom Lee e/Tom@gmail.com` and not `Tim Shum e/Tim@yahoo.com`.
 
 Examples:
-* `search John` returns `john` and `John Doe`
-* `search alex david` returns `Alex Yeoh`, `David Li`<br>
+* `filter John` returns `john` and `John Doe`
+* `filter alex david` returns `Alex Yeoh`, `David Li`<br>
 
 ### Clearing all entries : `clear`
 

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -12,5 +12,6 @@ public class Messages {
     public static final String MESSAGE_CLIENTS_LISTED_OVERVIEW = "%1$d clients listed!";
     public static final String MESSAGE_VIEW_SUCCESS = "Viewing client: %1$s";
     public static final String MESSAGE_SORT_SUCCESS = "List sorted by %s";
+    public static final String MESSAGE_FIELDS_EMPTY = "Inputs for the following attributes are empty: %s";
 
 }

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -21,7 +21,7 @@ public class StringUtil {
     public static final String TIME_VALIDATION_REGEX =
             "([01]?[0-9]|2[0-3]):[0-5][0-9]";
     public static final String CLIENT_DELIMITER = "\n";
-    public static final String CLIENTID_DELIMITER = ", ";
+    public static final String COMMA_DELIMITER = ", ";
     public static final String JSON_FILE_PREFIX = ".json";
 
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.StringUtil.COMMA_DELIMITER;
 import static seedu.address.commons.util.StringUtil.CLIENT_DELIMITER;
+import static seedu.address.commons.util.StringUtil.COMMA_DELIMITER;
 import static seedu.address.commons.util.StringUtil.joinListToString;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CURRENTPLAN;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.StringUtil.CLIENTID_DELIMITER;
+import static seedu.address.commons.util.StringUtil.COMMA_DELIMITER;
 import static seedu.address.commons.util.StringUtil.CLIENT_DELIMITER;
 import static seedu.address.commons.util.StringUtil.joinListToString;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
@@ -151,7 +151,7 @@ public class EditCommand extends Command {
             .collect(Collectors.toList());
 
         if (!invalidClientIds.isEmpty()) {
-            String invalidClientIdsString = joinListToString(invalidClientIds, CLIENTID_DELIMITER);
+            String invalidClientIdsString = joinListToString(invalidClientIds, COMMA_DELIMITER);
             throw new CommandException(String.format(Messages.MESSAGE_NONEXISTENT_CLIENT_ID, invalidClientIdsString));
         }
 

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -1,8 +1,15 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_FIELDS_EMPTY;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.ALL_PREFIXES;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import seedu.address.commons.mapper.PrefixMapper;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
@@ -14,7 +21,6 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      * and returns a FilterCommand object for execution.
      *
      * @throws ParseException if the user input does not conform the expected format
-     * @return
      */
     @Override
     public FilterCommand parse(String args, Model model) throws ParseException {
@@ -24,11 +30,23 @@ public class FilterCommandParser implements Parser<FilterCommand> {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }
 
-
         // appends " " in front as Filter Command can accept arguments without a preamble
         String preparedArgs = " ".concat(trimmedArgs);
         ArgumentMultimap argMultimap = ArgumentTokenizer
             .tokenize(preparedArgs, ALL_PREFIXES);
+
+        List<String> emptyInputPrefixes = Arrays.stream(ALL_PREFIXES)
+                .filter(prefix -> argMultimap.getValue(prefix)
+                        .map(String::isBlank)
+                        .orElse(false))
+                .map(PrefixMapper::getName)
+                .collect(Collectors.toList());
+
+        if (!emptyInputPrefixes.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_FIELDS_EMPTY,
+                    StringUtil.joinListToString(emptyInputPrefixes, StringUtil.COMMA_DELIMITER)));
+        }
+
         return new FilterCommand(new ClientContainsKeywordsPredicate(argMultimap));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
@@ -1,8 +1,15 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_FIELDS_EMPTY;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.ALL_PREFIXES;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import seedu.address.commons.mapper.PrefixMapper;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.SearchCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
@@ -24,14 +31,25 @@ public class SearchCommandParser implements Parser<SearchCommand> {
     public SearchCommand parse(String args, Model model) throws ParseException {
         String trimmedArgs = args.trim().replaceAll("\\s+", " ");
         if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
         }
 
         // appends " " in front as Search Command can accept arguments without a preamble
         String preparedArgs = " ".concat(trimmedArgs);
-        ArgumentMultimap argMultimap = ArgumentTokenizer
-            .tokenize(preparedArgs, ALL_PREFIXES);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(preparedArgs, ALL_PREFIXES);
+
+        List<String> emptyInputPrefixes = Arrays.stream(ALL_PREFIXES)
+                .filter(prefix -> argMultimap.getValue(prefix)
+                        .map(String::isBlank)
+                        .orElse(false))
+                .map(PrefixMapper::getName)
+                .collect(Collectors.toList());
+
+        if (!emptyInputPrefixes.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_FIELDS_EMPTY,
+                    StringUtil.joinListToString(emptyInputPrefixes, StringUtil.COMMA_DELIMITER)));
+        }
+
         return new SearchCommand(new ClientContainsKeywordsPredicate(argMultimap));
     }
 

--- a/src/main/java/seedu/address/model/client/ClientContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/client/ClientContainsKeywordsPredicate.java
@@ -54,7 +54,9 @@ public class ClientContainsKeywordsPredicate implements Predicate<Client> {
                 .map(Tag::getName)
                 .map(tagName -> (Function<String, Boolean>) x -> containsStringIgnoreCase(tagName, x))
                 .map(f -> keywords.getValue(PREFIX_TAG).map(f))
-                .anyMatch(o -> o.orElse(true));
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .reduce(true, Boolean::logicalOr);
 
         return checkGeneral && checkAttributes && checkTags;
     }

--- a/src/main/java/seedu/address/model/client/ClientContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/client/ClientContainsKeywordsPredicate.java
@@ -50,13 +50,12 @@ public class ClientContainsKeywordsPredicate implements Predicate<Client> {
                 })
                 .reduce(true, Boolean::logicalAnd);
 
-        boolean checkTags = client.getTags().stream()
-                .map(Tag::getName)
-                .map(tagName -> (Function<String, Boolean>) x -> containsStringIgnoreCase(tagName, x))
-                .map(f -> keywords.getValue(PREFIX_TAG).map(f))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .reduce(true, Boolean::logicalOr);
+        boolean checkTags = keywords.getValue(PREFIX_TAG)
+                .map(tagKeyword -> client.getTags().stream()
+                        .map(Tag::getName)
+                        .filter(tagName -> !tagName.isEmpty())
+                        .anyMatch(tagName -> containsStringIgnoreCase(tagName, tagKeyword)))
+                .orElse(true);
 
         return checkGeneral && checkAttributes && checkTags;
     }

--- a/src/main/java/seedu/address/model/client/ClientContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/client/ClientContainsKeywordsPredicate.java
@@ -36,7 +36,7 @@ public class ClientContainsKeywordsPredicate implements Predicate<Client> {
 
             boolean checkTags = client.getTags().stream()
                     .map(Tag::getName)
-                    .anyMatch(tagName -> tagName.equals(keyword));
+                    .anyMatch(tagName -> containsStringIgnoreCase(tagName, keyword));
 
             return checkAttributesLessTag || checkTags;
         });
@@ -54,7 +54,7 @@ public class ClientContainsKeywordsPredicate implements Predicate<Client> {
                 .map(Tag::getName)
                 .map(tagName -> (Function<String, Boolean>) x -> containsStringIgnoreCase(tagName, x))
                 .map(f -> keywords.getValue(PREFIX_TAG).map(f))
-                .allMatch(o -> o.orElse(true));
+                .anyMatch(o -> o.orElse(true));
 
         return checkGeneral && checkAttributes && checkTags;
     }

--- a/src/main/java/seedu/address/model/client/ClientContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/client/ClientContainsKeywordsPredicate.java
@@ -53,7 +53,6 @@ public class ClientContainsKeywordsPredicate implements Predicate<Client> {
         boolean checkTags = keywords.getValue(PREFIX_TAG)
                 .map(tagKeyword -> client.getTags().stream()
                         .map(Tag::getName)
-                        .filter(tagName -> !tagName.isEmpty())
                         .anyMatch(tagName -> containsStringIgnoreCase(tagName, tagKeyword)))
                 .orElse(true);
 

--- a/src/main/java/seedu/address/model/client/SortByAttribute.java
+++ b/src/main/java/seedu/address/model/client/SortByAttribute.java
@@ -46,7 +46,7 @@ public class SortByAttribute implements Comparator<Client> {
             resultList.add(getName(prefixIterator.next()) + " in " + sortDirectionIterator.next().toString());
         }
 
-        return StringUtil.joinListToString(resultList, StringUtil.CLIENTID_DELIMITER);
+        return StringUtil.joinListToString(resultList, StringUtil.COMMA_DELIMITER);
     }
 
     /**

--- a/src/main/java/seedu/address/model/client/exceptions/ClientNotFoundException.java
+++ b/src/main/java/seedu/address/model/client/exceptions/ClientNotFoundException.java
@@ -1,6 +1,6 @@
 package seedu.address.model.client.exceptions;
 
-import static seedu.address.commons.util.StringUtil.CLIENTID_DELIMITER;
+import static seedu.address.commons.util.StringUtil.COMMA_DELIMITER;
 import static seedu.address.commons.util.StringUtil.joinListToString;
 
 import java.util.List;
@@ -16,6 +16,6 @@ public class ClientNotFoundException extends RuntimeException {
     }
 
     public ClientNotFoundException(List<ClientId> notFound) {
-        super(joinListToString(notFound, CLIENTID_DELIMITER));
+        super(joinListToString(notFound, COMMA_DELIMITER));
     }
 }


### PR DESCRIPTION
### Description

Update the checking of tags in ClientContainsKeywords predicate to be check as intended and be case-insensitive.
Also, corrected the documentation for filter command from search to filter.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

1. Filter for tags using uppercase inputs
2. Filter for clients with multiple tags (e.g. `colleagues`)

### Checklist

- [X] I have tested this code
- [ ] I have updated the documentation
