### PR TITLE
Fix edit command for duplicate client id issue

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -11,7 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.allPrefixLess;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -40,7 +40,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, ALL_PREFIXES);
 
-        List<ClientId> clientIds = new ArrayList<>();
+        Set<ClientId> clientIds = new HashSet<>();
         try {
             String[] clientIdInput = argMultimap.getPreamble().split(" ");
             for (String s : clientIdInput) {
@@ -71,7 +71,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new EditCommand(clientIds, editClientDescriptor);
+        return new EditCommand(new ArrayList<>(clientIds), editClientDescriptor);
     }
 
     /**


### PR DESCRIPTION
### Description

Fix issue with edit command when duplicate client id is provided.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

`edit 1 1 r/2` should work the same as `edit 1 r/2`

### Checklist

<!-- Please delete options that are not relevant. -->

- [X] I have tested this code
- [ ] I have updated the documentation
