### PR TITLE
Fix same client bug

### DIFF
--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -132,7 +132,7 @@ public class Client {
         }
 
         return otherClient.getName().equals(getName())
-                || otherClient.getEmail().equals(getEmail());
+                && otherClient.getEmail().equals(getEmail());
     }
 
     public LocalDate getNextMeetingDate() {

--- a/src/test/java/seedu/address/model/client/ClientTest.java
+++ b/src/test/java/seedu/address/model/client/ClientTest.java
@@ -36,7 +36,7 @@ public class ClientTest {
         // null -> returns false
         assertFalse(ALICE.isSameClient(null));
 
-        // same email and client ID, all other attributes different -> returns true
+        // same email, name and client ID, all other attributes different -> returns true
         Client editedAlice = new ClientBuilder(ALICE).withPhone(VALID_PHONE_BOB)
                 .withAddress(VALID_ADDRESS_BOB).withRiskAppetite(VALID_RISKAPPETITE_BOB)
                 .withDisposableIncome(VALID_DISPOSABLEINCOME_BOB).withCurrentPlan(VALID_CURRENTPLAN_BOB)
@@ -47,9 +47,19 @@ public class ClientTest {
         editedAlice = new ClientBuilder(ALICE).withClientId(VALID_CLIENTID_BOB).build();
         assertTrue(ALICE.isSameClient(editedAlice));
 
-        // different email, all other attributes same -> returns true
-        editedAlice = new ClientBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build();
-        assertTrue(ALICE.isSameClient(editedAlice));
+        // same email, all other attributes different -> returns false
+        editedAlice = new ClientBuilder(ALICE).withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+                .withAddress(VALID_ADDRESS_BOB).withRiskAppetite(VALID_RISKAPPETITE_BOB)
+                .withDisposableIncome(VALID_DISPOSABLEINCOME_BOB).withCurrentPlan(VALID_CURRENTPLAN_BOB)
+                .withLastMet(VALID_LASTMET_BOB).withTags(VALID_TAG_HUSBAND).build();
+        assertFalse(ALICE.isSameClient(editedAlice));
+
+        // same name, all other attributes different -> returns false
+        editedAlice = new ClientBuilder(ALICE).withEmail(VALID_EMAIL_BOB).withPhone(VALID_PHONE_BOB)
+                .withAddress(VALID_ADDRESS_BOB).withRiskAppetite(VALID_RISKAPPETITE_BOB)
+                .withDisposableIncome(VALID_DISPOSABLEINCOME_BOB).withCurrentPlan(VALID_CURRENTPLAN_BOB)
+                .withLastMet(VALID_LASTMET_BOB).withTags(VALID_TAG_HUSBAND).build();
+        assertFalse(ALICE.isSameClient(editedAlice));
 
         // email and name differs in case, all other attributes same -> returns false
         Client editedBob = new ClientBuilder(BOB).withEmail(VALID_EMAIL_BOB.toUpperCase()).withName("Not Bob").build();


### PR DESCRIPTION
### Description

Fix bug where if new client has either same email or name as an existing client it would result in a error being thrown.  Now only new clients with same email or name will result in an error being thrown

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

<!-- Please delete options that are not relevant. -->

- [X] I have tested this code
- [ ] I have updated the documentation
