### PR TITLE
Expandable ClientViewPanel for attributes that can have long inputs

### DIFF
--- a/src/main/resources/view/ClientViewPanel.fxml
+++ b/src/main/resources/view/ClientViewPanel.fxml
@@ -17,8 +17,8 @@
         <VBox fx:id="cardPane" prefHeight="200.0" prefWidth="100.0" VBox.vgrow="ALWAYS">
             <children>
                 <HBox alignment="CENTER_LEFT" prefWidth="184.0" spacing="5">
-                    <Label styleClass="card_big_label" text="Name:"/>
-                    <Label fx:id="clientName" styleClass="card_big_label">
+                    <Label minWidth="-Infinity" styleClass="card_big_label" text="Name:"/>
+                    <Label minHeight="-Infinity" fx:id="clientName" styleClass="card_big_label" wrapText="true" >
                         <tooltip>
                             <Tooltip text="Name"/>
                         </tooltip>
@@ -33,24 +33,25 @@
                     </Label>
                 </HBox>
                 <HBox alignment="CENTER_LEFT" prefWidth="184.0" spacing="5">
-                    <Label styleClass="card_big_label" text="Contact Number:"/>
-                    <Label fx:id="clientPhoneNumber" styleClass="card_small_label">
+                    <Label minWidth="-Infinity" styleClass="card_big_label" text="Contact Number:"/>
+                    <Label minHeight="-Infinity" fx:id="clientPhoneNumber" styleClass="card_small_label"
+                           wrapText="true" >
                         <tooltip>
                             <Tooltip text="Contact Number"/>
                         </tooltip>
                     </Label>
                 </HBox>
                 <HBox alignment="CENTER_LEFT" prefWidth="184.0" spacing="5">
-                    <Label styleClass="card_big_label" text="Address:"/>
-                    <Label fx:id="clientAddress" styleClass="card_small_label">
+                    <Label minWidth="-Infinity" styleClass="card_big_label" text="Address:"/>
+                    <Label minHeight="-Infinity" fx:id="clientAddress" styleClass="card_small_label" wrapText="true" >
                         <tooltip>
                             <Tooltip text="Address"/>
                         </tooltip>
                     </Label>
                 </HBox>
                 <HBox alignment="CENTER_LEFT" prefWidth="184.0" spacing="5">
-                    <Label styleClass="card_big_label" text="Email Address:"/>
-                    <Label fx:id="clientEmail" styleClass="card_small_label">
+                    <Label minWidth="-Infinity" styleClass="card_big_label" text="Email Address:"/>
+                    <Label minHeight="-Infinity" fx:id="clientEmail" styleClass="card_small_label" wrapText="true" >
                         <tooltip>
                             <Tooltip text="Email Address"/>
                         </tooltip>
@@ -65,8 +66,9 @@
                     </Label>
                 </HBox>
                 <HBox alignment="CENTER_LEFT" prefWidth="184.0" spacing="5">
-                    <Label styleClass="card_big_label" text="Disposable Income:"/>
-                    <Label fx:id="clientDisposableIncome" styleClass="card_small_label">
+                    <Label minWidth="-Infinity" styleClass="card_big_label" text="Disposable Income:"/>
+                    <Label minHeight="-Infinity" fx:id="clientDisposableIncome" styleClass="card_small_label"
+                           wrapText="true" >
                         <tooltip>
                             <Tooltip text="Disposable Income"/>
                         </tooltip>


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

For most client attributes, there is no character limit for a user's inputs. This means that a user can purposely input long values for certain inputs (some of them might have no choice i.e. address), and the resulting ClientViewPanel will have truncated labels.

Thus, I have updated most of the client attributes to wrap text and expand if necessary, with the exception of values that are definitively short: ClientId, RiskAppetite and LastMet. A side effect of this change means that if multiple values are too long, the ViewPanel will end up eating into the Meeting List's space.

<img width="495" alt="Screenshot 2021-11-03 at 7 52 34 PM" src="https://user-images.githubusercontent.com/77223551/140061354-7bd5812a-a804-4d28-ad58-00f4cb0a7c23.png">

Alternatively, we can limit the number of characters to solve this issue as well
### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [ ] I have tested this code
- [ ] I have updated the documentation
