### PR TITLE
Update LastMet and NextMeeting validity checks

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -129,8 +129,11 @@ public class ParserUtil {
     public static LastMet parseLastMet(String lastMet) throws ParseException {
         requireNonNull(lastMet);
         String trimmedLastMet = lastMet.trim();
-        if (!StringUtil.isValidDate(trimmedLastMet)) {
+        if (!LastMet.isValidLastMet(trimmedLastMet)) {
             throw new ParseException(LastMet.MESSAGE_CONSTRAINTS);
+        }
+        if (!LastMet.isNotFutureDate(trimmedLastMet)) {
+            throw new ParseException(LastMet.MESSAGE_FUTURE_DATE);
         }
         return new LastMet(trimmedLastMet);
     }
@@ -159,6 +162,23 @@ public class ParserUtil {
         String endTime = trimmedNextMeeting.substring(trimmedNextMeeting.indexOf("~") + 1,
             trimmedNextMeeting.indexOf(")"));
         String location = trimmedNextMeeting.split(",", 2)[1].trim();
+
+        if (!NextMeeting.isValidNextMeetingDate(date)) {
+            throw new ParseException(NextMeeting.DATE_MESSAGE_CONSTRAINTS);
+        }
+        if (!NextMeeting.isValidNextMeetingTime(startTime)) {
+            throw new ParseException(NextMeeting.START_TIME_MESSAGE_CONSTRAINTS);
+        }
+        if (!NextMeeting.isValidNextMeetingTime(endTime)) {
+            throw new ParseException(NextMeeting.END_TIME_MESSAGE_CONSTRAINTS);
+        }
+        if (!NextMeeting.isNotPastMeeting(date, endTime)) {
+            throw new ParseException(NextMeeting.MESSAGE_MEETING_DATE_OVER);
+        }
+        if (!NextMeeting.isDurationValid(startTime, endTime)) {
+            throw new ParseException(NextMeeting.MESSAGE_INVALID_TIME_DURATION);
+        }
+
         return new NextMeeting(date, startTime, endTime, location, "");
     }
 

--- a/src/main/java/seedu/address/model/client/LastMet.java
+++ b/src/main/java/seedu/address/model/client/LastMet.java
@@ -12,6 +12,7 @@ import seedu.address.commons.util.StringUtil;
 public class LastMet implements OptionalNonStringBasedField, IgnoreNullComparable<LastMet> {
     public static final String MESSAGE_CONSTRAINTS = "LastMet should be in the form of Day-Month-Year, "
             + "where Day, month and year should be numerical values.";
+    public static final String MESSAGE_INVALID_LASTMET = "LastMet should not be a future date.";
 
     public final LocalDate value;
     public final String dateInString;
@@ -30,6 +31,7 @@ public class LastMet implements OptionalNonStringBasedField, IgnoreNullComparabl
         }
 
         checkArgument(isValidDate(lastMetDate), MESSAGE_CONSTRAINTS);
+        checkArgument(notFutureDate(lastMetDate), MESSAGE_INVALID_LASTMET);
         dateInString = lastMetDate;
 
         if (lastMetDate.isEmpty()) {
@@ -44,7 +46,18 @@ public class LastMet implements OptionalNonStringBasedField, IgnoreNullComparabl
      * Returns if a given string is a valid lastMet.
      */
     public static boolean isValidLastMet(String test) {
-        return StringUtil.isValidDate(test);
+        return StringUtil.isValidDate(test) && notFutureDate(test);
+    }
+
+    /**
+     * Returns if a given string contains a date that is not in the future.
+     */
+    public static boolean notFutureDate(String test) {
+        if (test.isEmpty()) {
+            return true;
+        }
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy");
+        return !LocalDate.parse(test, formatter).isAfter(LocalDate.now());
     }
 
     /**

--- a/src/main/java/seedu/address/model/client/LastMet.java
+++ b/src/main/java/seedu/address/model/client/LastMet.java
@@ -10,8 +10,8 @@ import seedu.address.commons.util.StringUtil;
 
 public class LastMet implements OptionalNonStringBasedField, IgnoreNullComparable<LastMet> {
     public static final String MESSAGE_CONSTRAINTS = "LastMet should be in the form of Day-Month-Year, "
-            + "where Day, month and year should be numerical values.";
-    public static final String MESSAGE_INVALID_LASTMET = "LastMet should not be a future date.";
+            + "where Day, Month and Year should be valid numerical values.";
+    public static final String MESSAGE_FUTURE_DATE = "LastMet should not be a future date.";
 
     public final LocalDate value;
     public final String dateInString;
@@ -33,6 +33,7 @@ public class LastMet implements OptionalNonStringBasedField, IgnoreNullComparabl
         }
 
         checkArgument(isValidLastMet(lastMetDate), MESSAGE_CONSTRAINTS);
+        checkArgument(isNotFutureDate(lastMetDate), MESSAGE_FUTURE_DATE);
         dateInString = lastMetDate;
 
         if (lastMetDate.isEmpty()) {
@@ -44,10 +45,10 @@ public class LastMet implements OptionalNonStringBasedField, IgnoreNullComparabl
     }
 
     /**
-     * Returns if a given string is a valid lastMet.
+     * Returns if a given string is a valid LastMet string representation.
      */
     public static boolean isValidLastMet(String test) {
-        return (IS_NULL_VALUE_ALLOWED && test.isEmpty()) || (StringUtil.isValidDate(test) && isNotFutureDate(test));
+        return (IS_NULL_VALUE_ALLOWED && test.isEmpty()) || StringUtil.isValidDate(test);
     }
 
     /**

--- a/src/main/java/seedu/address/model/client/NextMeeting.java
+++ b/src/main/java/seedu/address/model/client/NextMeeting.java
@@ -15,12 +15,15 @@ import java.time.LocalTime;
 public class NextMeeting implements OptionalNonStringBasedField, IgnoreNullComparable<NextMeeting> {
 
     public static final String DATE_MESSAGE_CONSTRAINTS = "Next meeting date should be in the form of Day-Month-Year, "
-            + "where Day, month and year should be numerical values.";
-    public static final String TIME_MESSAGE_CONSTRAINTS = "Next meeting time should be in the 24-hour format, "
-            + "where Hour and Minutes should be numerical values.";
-    public static final String MESSAGE_INVALID_MEETING_STRING = "String representation of Next Meeting is not correct";
-    public static final String MESSAGE_INVALID_TIME_DURATION = "End Time should be after Start Time";
-    public static final String MESSAGE_INVALID_MEETING_DATE_OVER = "NextMeeting should not be in the past";
+            + "where Day, Month and Year should be valid numerical values.";
+    public static final String START_TIME_MESSAGE_CONSTRAINTS = "Start time should be in the 24-hour format, "
+            + "where Hour and Minutes should be valid numerical values.";
+    public static final String END_TIME_MESSAGE_CONSTRAINTS = "End time should be in the 24-hour format, "
+            + "where Hour and Minutes should be valid numerical values.";
+    public static final String MESSAGE_INVALID_MEETING_STRING = "String representation of Next Meeting is not correct."
+            + "It should be in the form of m/dd-MM-yyyy (hh:mm~hh:mm), {location}";
+    public static final String MESSAGE_INVALID_TIME_DURATION = "End Time should be after Start Time.";
+    public static final String MESSAGE_MEETING_DATE_OVER = "NextMeeting should not be in the past.";
     public static final String NO_NEXT_MEETING = "No meeting planned";
     public static final NextMeeting NULL_MEETING = new NextMeeting(null, null, null,
             null, null);
@@ -57,14 +60,14 @@ public class NextMeeting implements OptionalNonStringBasedField, IgnoreNullCompa
         checkArgument(isValidNextMeetingDate(date), DATE_MESSAGE_CONSTRAINTS);
         dateInString = date;
 
-        checkArgument(isValidNextMeetingTime(startTime), TIME_MESSAGE_CONSTRAINTS);
+        checkArgument(isValidNextMeetingTime(startTime), START_TIME_MESSAGE_CONSTRAINTS);
         startTimeInString = startTime;
 
-        checkArgument(isValidNextMeetingTime(endTime), TIME_MESSAGE_CONSTRAINTS);
+        checkArgument(isValidNextMeetingTime(endTime), END_TIME_MESSAGE_CONSTRAINTS);
         endTimeInString = endTime;
 
         checkArgument(isDurationValid(startTime, endTime), MESSAGE_INVALID_TIME_DURATION);
-        checkArgument(isNotPastMeeting(date, endTime), MESSAGE_INVALID_MEETING_DATE_OVER);
+        checkArgument(isNotPastMeeting(date, endTime), MESSAGE_MEETING_DATE_OVER);
 
         this.withWho = withWho.isEmpty() ? null : new Name(withWho);
 
@@ -116,24 +119,10 @@ public class NextMeeting implements OptionalNonStringBasedField, IgnoreNullCompa
     }
 
     /**
-     * Returns a boolean of the given {@code test} is a valid NextMeeting string
+     * Returns a boolean if the given {@code test} is a valid NextMeeting string
      */
     public static boolean isValidNextMeeting(String test) {
-        if (IS_NULL_VALUE_ALLOWED && test.isEmpty()) {
-            return true;
-        }
-        if (!test.matches(VALID_MEETING_STRING)) {
-            return false;
-        }
-        String date = test.split(" ", 2)[0];
-        String startTime = test.substring(test.indexOf("(") + 1, test.indexOf("~"));
-        String endTime = test.substring(test.indexOf("~") + 1, test.indexOf(")"));
-
-        return isDurationValid(startTime, endTime) && isNotPastMeeting(date, endTime);
-    }
-
-    public Name getWithWho() {
-        return this.withWho;
+        return (IS_NULL_VALUE_ALLOWED && test.isEmpty()) || test.matches(VALID_MEETING_STRING);
     }
 
     public void setWithWho(Name withWho) {

--- a/src/test/java/seedu/address/model/client/LastMetTest.java
+++ b/src/test/java/seedu/address/model/client/LastMetTest.java
@@ -64,7 +64,7 @@ public class LastMetTest {
     }
 
     @Test
-    public void notFutureDate() {
+    public void isNotFutureDate() {
         // used in conjunction with isValidDate, so assume dates to be valid
 
         // empty string

--- a/src/test/java/seedu/address/model/client/LastMetTest.java
+++ b/src/test/java/seedu/address/model/client/LastMetTest.java
@@ -37,9 +37,6 @@ public class LastMetTest {
         assertFalse(LastMet.isValidLastMet("60-08-2010"));
         assertFalse(LastMet.isValidLastMet("5654-08-12"));
 
-        // invalid date (in the future)
-        assertFalse(LastMet.isValidLastMet("25-12-3000"));
-
         // valid date
         assertTrue(LastMet.isValidLastMet("20-12-1999"));
         assertTrue(LastMet.isValidLastMet("20-09-2021"));

--- a/src/test/java/seedu/address/model/client/LastMetTest.java
+++ b/src/test/java/seedu/address/model/client/LastMetTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import org.junit.jupiter.api.Test;
 
 public class LastMetTest {
@@ -13,6 +16,9 @@ public class LastMetTest {
     public void constructor_invalidLastMet_throwsIllegalArgumentException() {
         String invalidLastMet = "hello";
         assertThrows(IllegalArgumentException.class, () -> new LastMet(invalidLastMet));
+
+        String futureDate = "25-12-3000";
+        assertThrows(IllegalArgumentException.class, () -> new LastMet(futureDate));
     }
 
     @Test
@@ -31,10 +37,13 @@ public class LastMetTest {
         assertFalse(LastMet.isValidLastMet("60-08-2010"));
         assertFalse(LastMet.isValidLastMet("5654-08-12"));
 
+        // invalid date (in the future)
+        assertFalse(LastMet.isValidLastMet("25-12-3000"));
+
         // valid date
-        assertTrue(LastMet.isValidLastMet("20-12-2021"));
+        assertTrue(LastMet.isValidLastMet("20-12-1999"));
         assertTrue(LastMet.isValidLastMet("20-09-2021"));
-        assertTrue(LastMet.isValidLastMet("30-12-2021"));
+        assertTrue(LastMet.isValidLastMet(LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-yyyy")))); // today
     }
 
     @Test
@@ -52,5 +61,23 @@ public class LastMetTest {
         assertEquals(lastMetA.getLaterLastMet(lastMetB), lastMetA);
         assertEquals(lastMetB.getLaterLastMet(lastMetA), lastMetA);
         assertEquals(lastMetB.getLaterLastMet(lastMetB), lastMetB);
+    }
+
+    @Test
+    public void notFutureDate() {
+        // used in conjunction with isValidDate, so assume dates to be valid
+
+        // empty string
+        assertTrue(LastMet.notFutureDate(""));
+
+        // past date
+        assertTrue(LastMet.notFutureDate("20-12-1999"));
+        assertTrue(LastMet.notFutureDate("20-09-2021"));
+
+        // current date
+        assertTrue(LastMet.notFutureDate(LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-yyyy"))));
+
+        // future date
+        assertFalse(LastMet.notFutureDate("20-12-2050"));
     }
 }

--- a/src/test/java/seedu/address/model/client/NextMeetingTest.java
+++ b/src/test/java/seedu/address/model/client/NextMeetingTest.java
@@ -7,6 +7,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 import org.junit.jupiter.api.Test;
 
@@ -42,6 +43,44 @@ public class NextMeetingTest {
     }
 
     @Test
+    public void isDurationValid() {
+        // empty string
+        assertTrue(NextMeeting.isDurationValid("", ""));
+
+        // invalid time string
+        assertFalse(NextMeeting.isDurationValid("00:61", "02:00"));
+        assertFalse(NextMeeting.isDurationValid("00:00", "25:00"));
+
+        // end time < start time
+        assertFalse(NextMeeting.isDurationValid("13:00", "08:00"));
+
+        // start time < end time
+        assertTrue(NextMeeting.isDurationValid("08:00", "13:00"));
+    }
+
+    @Test
+    public void notPastMeeting() {
+        String validDate = "24-12-2050";
+        String validEndTime = "13:00";
+
+        // empty string
+        assertTrue(NextMeeting.notPastMeeting("", ""));
+
+        // invalid strings
+        assertFalse(NextMeeting.notPastMeeting("24-20-2050", "02:00"));
+        assertFalse(NextMeeting.notPastMeeting("24-12-2050", "25:00"));
+        assertFalse(NextMeeting.notPastMeeting("24-12-2050", "23:61"));
+
+        // meeting datetime is in the past
+        assertFalse(NextMeeting.notPastMeeting("24-12-2020", "00:00"));
+
+        // meeting datetime is in the future
+        assertTrue(NextMeeting.notPastMeeting(LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-yyyy")),
+            "23:59"));
+        assertTrue(NextMeeting.notPastMeeting("24-12-2050", "00:00"));
+    }
+
+    @Test
     public void isValidNextMeetingString() {
         // null
         assertThrows(NullPointerException.class, () -> NextMeeting.isValidNextMeeting(null));
@@ -54,9 +93,15 @@ public class NextMeetingTest {
         assertFalse(NextMeeting.isValidNextMeeting("24-12-2021, Starbucks @ UTown"));
         assertFalse(NextMeeting.isValidNextMeeting("24-12-2021 (10:00~12:00),    "));
 
+        // invalid time duration
+        assertFalse(NextMeeting.isValidNextMeeting("24-12-2050 (13:00~12:59), Starbucks @ UTown"));
+
+        // past meeting
+        assertFalse(NextMeeting.isValidNextMeeting("24-12-2010 (12:00~12:59), Starbucks @ UTown"));
+
         // valid next meeting
-        assertTrue(NextMeeting.isValidNextMeeting("24-12-2021 (10:00~12:00), Starbucks @ UTown"));
-        assertTrue(NextMeeting.isValidNextMeeting("25-12-2021 (14:00~17:00), null"));
+        assertTrue(NextMeeting.isValidNextMeeting("24-12-2050 (10:00~12:00), Starbucks @ UTown"));
+        assertTrue(NextMeeting.isValidNextMeeting("25-12-2050 (14:00~17:00), null"));
     }
 
     @Test
@@ -82,9 +127,11 @@ public class NextMeetingTest {
 
     @Test
     public void convertToLastMet() {
-        String date = "09-10-2022";
-        String startTime = "11:00";
-        String endTime = "12:00";
+        // LastMet can only be a date that has passed/today's date
+        // while NextMeeting has to have Date/Time that has not passed, so we will test with CurrentDate
+        String date = LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-yyyy"));
+        String startTime = "23:58";
+        String endTime = "23:59";
         String location = "Zoom";
         String name = "ben";
 

--- a/src/test/java/seedu/address/model/client/NextMeetingTest.java
+++ b/src/test/java/seedu/address/model/client/NextMeetingTest.java
@@ -59,7 +59,7 @@ public class NextMeetingTest {
     }
 
     @Test
-    public void notPastMeeting() {
+    public void isNotPastMeeting() {
         String validDate = "24-12-2050";
         String validEndTime = "13:00";
 

--- a/src/test/java/seedu/address/model/client/NextMeetingTest.java
+++ b/src/test/java/seedu/address/model/client/NextMeetingTest.java
@@ -93,12 +93,6 @@ public class NextMeetingTest {
         assertFalse(NextMeeting.isValidNextMeeting("24-12-2021, Starbucks @ UTown"));
         assertFalse(NextMeeting.isValidNextMeeting("24-12-2021 (10:00~12:00),    "));
 
-        // invalid time duration
-        assertFalse(NextMeeting.isValidNextMeeting("24-12-2050 (13:00~12:59), Starbucks @ UTown"));
-
-        // past meeting
-        assertFalse(NextMeeting.isValidNextMeeting("24-12-2010 (12:00~12:59), Starbucks @ UTown"));
-
         // valid next meeting
         assertTrue(NextMeeting.isValidNextMeeting("24-12-2050 (10:00~12:00), Starbucks @ UTown"));
         assertTrue(NextMeeting.isValidNextMeeting("25-12-2050 (14:00~17:00), null"));


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

LastMet now has checks that prevents users from inputting future dates (which does not make sense and is a potential featureFlaw)

Also, updates isValidLastMet as well as isValidNextMeeting that was missed out in #198 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [X] I have tested this code
- [ ] I have updated the documentation
