### PR TITLE
Fix ab list command not displaying new address book on first start

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -165,11 +165,12 @@ public class MainApp extends Application {
         ReadOnlyAddressBook initialData;
         try {
             addressBookOptional = storage.readAddressBook();
+            initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
+
             if (addressBookOptional.isEmpty()) {
                 logger.info("Data file not found. Will be starting with a sample AddressBook");
+                storage.saveAddressBook(initialData);
             }
-
-            initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
         } catch (DataConversionException e) {
             logger.warning("Data file not in the correct format. Will be starting with an empty AddressBook");
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -38,7 +38,6 @@ public class ModelManager implements Model {
     private final SortedList<Client> sortedClients;
     private final FilteredList<Client> filteredClients;
     private final FilteredList<Client> clientToView;
-    private final SortedList<Client> sortedNextMeetings;
     private final FilteredList<Client> shownNextMeetings;
     private final FilteredList<Tag> filteredTags;
     private final AddressBookList addressBookList;
@@ -66,14 +65,13 @@ public class ModelManager implements Model {
         sortedClients = new SortedList<>(clientList);
         filteredClients = new FilteredList<>(sortedClients);
 
-        sortedNextMeetings = new SortedList<>(checkAllNextMeetings(this.addressBook.getClientList()));
-        shownNextMeetings = new FilteredList<>(sortedNextMeetings);
+        shownNextMeetings = new FilteredList<>(checkAllNextMeetings(clientList));
 
 
         // TODO: filter by colors, etc
         filteredTags = new FilteredList<>(this.addressBook.getTagList());
 
-        clientToView = new FilteredList<>(this.addressBook.getClientList());
+        clientToView = new FilteredList<>(clientList);
         clientToView.setPredicate(PREDICATE_SHOW_ALL_CLIENTS.negate());
     }
 


### PR DESCRIPTION
### Description

Fix `ab list` command to display the current address book when LeadsForce first boot up.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Delete address book json file so that LeadsForce will have to boot up with a fresh addressbook.
Execute `ab list`, addressbook should be displayed (previously this was not being displayed)

### Checklist

- [X] I have tested this code
- [ ] I have updated the documentation
